### PR TITLE
Deduce Git Remote

### DIFF
--- a/build-functions.php
+++ b/build-functions.php
@@ -128,3 +128,18 @@ function escapeNamespaceForQuote($namespace)
 {
     return preg_replace('/\\\\+/', '\\\\\\\\', $namespace);
 }
+
+/**
+ * Builds a GitHub repo URL from vendor and package information.
+ *
+ * @since [*next-version*]
+ *
+ * @param string $vendor  The package vendor.
+ * @param string $package The package slug name.
+ *
+ * @return string
+ */
+function buildGitHubRepoUrl($vendor, $package)
+{
+    return sprintf('https://github.com/%1$s/%2$s.git', $vendor, $package);
+}

--- a/build.xml
+++ b/build.xml
@@ -72,6 +72,9 @@
             <propertyprompt useExistingValue="true" defaultValue="${default.composer.phpver}"       propertyName="composer.phpver"       promptText="PHP Version Constraint" />
             <propertyprompt useExistingValue="true" defaultValue="${default.composer.autoload.ns}"  propertyName="autoload.ns"           promptText="PSR-4 Autoload Namespace" />
             <propertyprompt useExistingValue="true" defaultValue="${default.composer.autoload.dir}" propertyName="composer.autoload.dir" promptText="PSR-4 Autoload Directory" />
+
+            <!-- Prompt for git remote -->
+            <php expression="buildGitHubRepoUrl('${composer.vendor}', '${composer.name}')" returnProperty="default.git.remote" />
             <propertyprompt useExistingValue="true" defaultValue="${default.git.remote}"            propertyName="git.remote"            promptText="Git Remote URL" />
         </then>
     </if>


### PR DESCRIPTION
Attempts to incorporate a solution for #12 

----

The Git remote is now deduced from the package slug and vendor into GitHub repository URLs. This is displayed as a default value for the Git remote prompt, which means that alternate remote URLs can still be provided.