### PR TITLE
Fixes non-absolute FQNs in test templates

### DIFF
--- a/test/functional/MyClassTest.php
+++ b/test/functional/MyClassTest.php
@@ -5,7 +5,7 @@ namespace {{ns}}\FuncTest;
 use Xpmock\TestCase;
 
 /**
- * Tests {@see {{ns}}\MyClass}.
+ * Tests {@see \{{ns}}\MyClass}.
  *
  * @TODO Search and replace tokens that begin with underscore.
  *
@@ -25,7 +25,7 @@ class MyClassTest extends TestCase
      *
      * @since [*next-version*]
      *
-     * @return {{ns}}\MyClass
+     * @return \{{ns}}\MyClass
      */
     public function createInstance()
     {

--- a/test/unit/MyClassTest.php
+++ b/test/unit/MyClassTest.php
@@ -5,7 +5,7 @@ namespace {{ns}}\FuncTest;
 use Xpmock\TestCase;
 
 /**
- * Tests {@see {{ns}}\MyClass}.
+ * Tests \{@see {{ns}}\MyClass}.
  *
  * @since [*next-version*]
  */
@@ -16,7 +16,7 @@ class MyClassTest extends TestCase
      *
      * @since [*next-version*]
      *
-     * @return {{ns}}\MyClass
+     * @return \{{ns}}\MyClass
      */
     public function createInstance()
     {


### PR DESCRIPTION
Attempts to incorporate a solution for #10 

----

The `see` and `return` tags in the test templates referenced classes with an FQN without a leading slash. This has been fixed so that all FQNs are now absolute.