### PR TITLE
Readme badges shows status for develop branch

### DIFF
--- a/README.md.template
+++ b/README.md.template
@@ -1,6 +1,6 @@
 # {{organization}} - {{project}}
 
-[![Build Status](https://travis-ci.org/{{composer.vendor}}/{{composer.name}}.svg?branch=master)](https://travis-ci.org/{{composer.vendor}}/{{composer.name}})
+[![Build Status](https://travis-ci.org/{{composer.vendor}}/{{composer.name}}.svg?branch=develop)](https://travis-ci.org/{{composer.vendor}}/{{composer.name}})
 [![Code Climate](https://codeclimate.com/github/{{composer.vendor}}/{{composer.name}}/badges/gpa.svg)](https://codeclimate.com/github/{{composer.vendor}}/{{composer.name}})
 [![Test Coverage](https://codeclimate.com/github/{{composer.vendor}}/{{composer.name}}/badges/coverage.svg)](https://codeclimate.com/github/{{composer.vendor}}/{{composer.name}}/coverage)
 [![Latest Stable Version](https://poser.pugx.org/{{composer.vendor}}/{{composer.name}}/version)](https://packagist.org/packages/{{composer.vendor}}/{{composer.name}})


### PR DESCRIPTION
Attempts to incorporate a solution for #22 

----

As discussed in issue #22, the only badge that is relevant for this change is the TravisCI badge.